### PR TITLE
Add composer.lock to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmp/
 
 # Others
 .DS_Store
+composer.lock


### PR DESCRIPTION
As it should be commited with a library, it would make no sense
