### PR TITLE
Upgrade cakephp dependency to 2.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
 			"type": "package",
 			"package": {
 				"name": "cakephp/cakephp",
-				"version": "2.4.1",
+				"version": "2.4.3",
 				"dist": {
-					"url": "https://github.com/cakephp/cakephp/archive/2.4.1.zip",
+					"url": "https://github.com/cakephp/cakephp/archive/2.4.3.zip",
 					"type": "zip"
 				},
 				"include-path": ["lib/"]


### PR DESCRIPTION
In the future, we should maybe use the pear repo ?
