### PR TITLE
Removed Asset.timestamp configuration

### DIFF
--- a/Config/croogo.php.install
+++ b/Config/croogo.php.install
@@ -190,16 +190,6 @@ Configure::write('Security.salt', 'f78b12a5c38e9e5c6ae6fbd0ff1f46c77a1e305d');
 Configure::write('Security.cipherSeed', '60170779348589376');
 
 /**
- * Apply timestamps with the last modified time to static assets (js, css, images).
- * Will append a querystring parameter containing the time the file was modified. This is
- * useful for invalidating browser caches.
- *
- * Set to `true` to apply timestamps when debug > 0. Set to 'force' to always enable
- * timestamping regardless of debug value.
- */
-//Configure::write('Asset.timestamp', true);
-
-/**
  * Compress CSS output by removing comments, whitespace, repeating tags, etc.
  * This requires a/var/cache directory to be writable by the web server for caching.
  * and /vendors/csspp/csspp.php


### PR DESCRIPTION
since it is now an available Setting in Croogo (related to croogo/croogo#287)
