### PR TITLE
Activate Dashboards plugin

### DIFF
--- a/Config/croogo.php.install
+++ b/Config/croogo.php.install
@@ -35,6 +35,11 @@
 Configure::write('debug', 1);
 
 /**
+ * Set a default language
+ */
+Configure::write('defaultLanguage', 'eng');
+
+/**
  * Configure the Error handler used to handle errors for your application.  By default
  * ErrorHandler::handleError() is used.  It will display errors using Debugger, when debug > 0
  * and log errors with CakeLog when debug = 0.

--- a/Config/settings.json.install
+++ b/Config/settings.json.install
@@ -11,7 +11,7 @@
 		"title": "Croogo"
 	},
 	"Hook": {
-		"bootstraps": "Settings,Comments,Contacts,Nodes,Meta,Menus,Users,Blocks,Taxonomy,FileManager,Wysiwyg,Ckeditor"
+		"bootstraps": "Settings,Comments,Contacts,Nodes,Meta,Menus,Users,Blocks,Taxonomy,FileManager,Dashboards,Wysiwyg,Ckeditor"
 	},
 	"Comment": {
 		"date_time_format": "M d, Y",

--- a/webroot/css/index.html
+++ b/webroot/css/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/webroot/img/index.html
+++ b/webroot/img/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/webroot/js/index.html
+++ b/webroot/js/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/webroot/robots.txt
+++ b/webroot/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+
+Disallow: /admin/
+Disallow: /js/
+Disallow: /css/
+
+Sitemap: http://www.example.com/sitemap.xml


### PR DESCRIPTION
Dashboards plugin is not activated by default installation, i think it should activate by default installation, also i think we should add a plugin.json file into dashboard/config to let the user the ability to activate or disactivate it
