### PR TITLE
Switch Vendor/cakephp/cakephp to 2.7 branch

### DIFF
--- a/Console/add_submodule
+++ b/Console/add_submodule
@@ -38,7 +38,7 @@ $repos = array(
 	'cakephp' => array(
 		'url' => 'http://github.com/cakephp/cakephp',
 		'target' => 'Vendor/cakephp/cakephp',
-		'branch' => 'master',
+		'branch' => '2.7',
 	),
 	'croogo' => array(
 		'url' => 'http://github.com/croogo/croogo',


### PR DESCRIPTION
Vendor/cakephp/cakephp master branch is now onto 3.x, which is incompatible with Croogo.  

Branch 2.7 is the latest production version Croogo can use.